### PR TITLE
잘못된 key로 가상환경 로드할 때 예외 처리, start.sh 제대로 적용

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,8 +92,11 @@ def create():
     
     os.popen(copyScriptToContainer(containerId))
     
+    time.sleep(1)
+    
     #os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
-    os.popen("docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd)
+    changeVncScopeAndControlCmd = "docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
+    os.popen(changeVncScopeAndControlCmd)
 
     
     response = {
@@ -113,6 +116,7 @@ def load() :
     requestDTO = request.get_json()
     print("[load requestDTO] ", requestDTO)
     userId, port, pwd, imageId = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['password']), str(requestDTO['key'])
+    scope, control = str(requestDTO['scope']), str(requestDTO['control'])
     deImageId = aes.decrypt(imageId)
     
     stream1 = os.popen(createContainerCmd(port, pwd, deImageId))
@@ -123,7 +127,7 @@ def load() :
             'imageId' : enImageId
         }
         
-        return jsonify(response), 500 
+        return jsonify(response), 404 
     
     newContainerId = stream1.read()[:12]
     enContainerId = aes.encrypt(newContainerId)
@@ -136,7 +140,10 @@ def load() :
     
     os.popen(copyScriptToContainer(newContainerId))
     
-    os.popen("docker exec -it --user root "+newContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd)
+    time.sleep(1)
+    
+    changeVncScopeAndControlCmd = "docker exec -it --user root "+newContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
+    os.popen(changeVncScopeAndControlCmd)
 
     
     response = {
@@ -164,8 +171,8 @@ def start():
     time.sleep(1)
     
     #os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
-    os.popen("docker exec -it --user root "+deContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd 
-)
+    changeVncScopeAndControlCmd = "docker exec -it --user root "+deContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
+    os.popen(changeVncScopeAndControlCmd)
     
     response = {
             'port' : port,
@@ -173,7 +180,6 @@ def start():
         }
     
     return jsonify(response), 200
-
 
 
 # spring 서버에서 컨테이너 중지 요청이 왔을 때, 컨테이너 중지
@@ -227,7 +233,6 @@ def save() :
         }
     
     return jsonify(response), 200
-
 
 
 # spring 서버에서 컨테이너 삭제 요청이 왔을 때, 컨테이너, 이미지 삭제  

--- a/app.py
+++ b/app.py
@@ -92,7 +92,9 @@ def create():
     
     os.popen(copyScriptToContainer(containerId))
     
-    os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
+    #os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
+    os.popen("docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd)
+
     
     response = {
             'port': port,
@@ -114,6 +116,15 @@ def load() :
     deImageId = aes.decrypt(imageId)
     
     stream1 = os.popen(createContainerCmd(port, pwd, deImageId))
+    # 해당 이미지 id가 없을 때
+    if (stream1.read()[:6] == 'Unable') :
+        response = {
+            'containerId' : 'null',
+            'imageId' : enImageId
+        }
+        
+        return jsonify(response), 500 
+    
     newContainerId = stream1.read()[:12]
     enContainerId = aes.encrypt(newContainerId)
     
@@ -124,6 +135,9 @@ def load() :
     os.popen(startContainerCmd(newContainerId))
     
     os.popen(copyScriptToContainer(newContainerId))
+    
+    os.popen("docker exec -it --user root "+newContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd)
+
     
     response = {
         'containerId' : enContainerId,
@@ -149,7 +163,9 @@ def start():
     
     time.sleep(1)
     
-    os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
+    #os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
+    os.popen("docker exec -it --user root "+deContainerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd 
+)
     
     response = {
             'port' : port,


### PR DESCRIPTION
- 잘못된 key로 가상환경 로드할 때 예외 처리
- 가상환경 생성, 로드할 때 start.sh 제대로 적용되지 않는 문제 해결
- 가상환경 로드할 때 공개 범위, 접속자 권한 범위 데이터 설정할 수 있게 추가