### PR TITLE
kubernetes Pod 생성 및 관리 코드 

### DIFF
--- a/app_v2.py
+++ b/app_v2.py
@@ -306,7 +306,7 @@ def stop():
     print("[stop requestDTO] ", requestDTO)
     port, containerId = str(requestDTO['port']), str(requestDTO['containerId'])
     deContainerId = aes.decrypt(containerId)
-    vmName = str(requestDTO['vmname'])
+    vmName = "vm"+port
 
     # os.popen(stopContainerCmd(deContainerId))
 

--- a/app_v2.py
+++ b/app_v2.py
@@ -174,6 +174,8 @@ def create():
 
     os.popen(copyScriptToContainer(containerId))
 
+    os.popen(stopContainerCmd(containerId))
+
     #os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
     #cmd1= "docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
     #os.popen(cmd1)
@@ -228,6 +230,8 @@ def load() :
     os.popen(startContainerCmd(newContainerId))
 
     os.popen(copyScriptToContainer(newContainerId))
+
+    os.popen(stopContainerCmd(newContainerId))
 
     # Depolyment yaml 파일 생성 
     deploymentPodYaml = generateDeploymentPodYaml(vmName, vmName, imageId, port, scriptPath, scope, control, pwd)

--- a/app_v2.py
+++ b/app_v2.py
@@ -94,7 +94,8 @@ def deleteServicePodCmd(serviceName):
 
 # 컨테이너 관련 명령어
 def createContainerCmd(port, pwd, imageId) : # vm+port 이름의 컨테이너 생성
-    return "docker create --shm-size=512m -p "+port+":6901 -e VNC_PW="+pwd+" --name vm"+port+" "+imageId
+    vmname = "vm"+port
+    return "docker create --shm-size=512m -p "+port+":6901 -e VNC_PW="+pwd+" --name "+vmname+" "+imageId
 
 def startContainerCmd(containerId) :    # containerid로 컨테이너 실행 
     return "docker start "+containerId
@@ -149,8 +150,8 @@ aes = AESCipher(key)
 
 
 # spring 서버에서 컨테이너 생성 요청이 왔을 때, base 이미지로 컨테이너 생성하고 이미지 저장
-@app.route('/create', methods=['POST'])
-def create():
+@app.route('/create', methods=['POST']) 
+def create(): 
 
     requestDTO = request.get_json()
     print("[create requestDTO] ", requestDTO)
@@ -165,9 +166,9 @@ def create():
     stream2 = os.popen(createImgCmd(containerId, userId, port))
     imageId = stream2.read()[7:20]
     enImageId = aes.encrypt(imageId)  # imageId 암호화
-    vmName = str(requestDTO['vmname'])
-    scriptPath = "/dockerstartup/start.sh"
-    nodePort = str(requestDTO['nodePort'])
+    vmName = "vm"+port
+    scriptPath = "/dockerstartup/start.sh" 
+    nodePort = str(requestDTO['nodePort']) 
 
     os.popen(startContainerCmd(containerId))
 
@@ -220,7 +221,7 @@ def load() :
     enImageId = aes.encrypt(newImageId)
 
     scope, control = str(requestDTO['scope']), str(requestDTO['control'])
-    vmName = str(requestDTO['vmname'])
+    vmName = "vm"+port
     scriptPath = "/dockerstartup/start.sh"
     nodePort = str(requestDTO['nodePort'])
 
@@ -263,7 +264,7 @@ def start():
     pwd = str(requestDTO['password'])
     scope, control = str(requestDTO['scope']), str(requestDTO['control'])
 
-    vmName = str(requestDTO['vmname'])
+    vmName = "vm"+port
 
     #os.popen(startContainerCmd(deContainerId)) Pod를 생성하면 자동으로 container가 실행되기 때문에 사용 안 함 
 

--- a/app_v2.py
+++ b/app_v2.py
@@ -80,7 +80,7 @@ def generateServiceYaml(serviceName, servicePort, nodePort):
 
 # Pod yaml로 생성하기 
 def applyPodCmd(yamlFile):
-    return "kubectl apply -f" + yamlFile
+    return "kubectl apply -f " + yamlFile
 
 # deployment Pod 지우기  
 def deleteDeployPodCmd(deploymentName): 

--- a/app_v2.py
+++ b/app_v2.py
@@ -2,13 +2,13 @@ from flask import Flask, render_template, request, jsonify
 import os, time
 import base64
 import hashlib
-from Crypto.Cipher import AES
 import yaml
+from Crypto.Cipher import AES
 
 app = Flask(__name__)
 
-baseImageId = '04a27ba84906' # kasm-1.14.0 이미지 
-#baseImageId = '1692c5f95a70e' # 로컬 이미지 
+baseImageId = 'a1f78e91446e' # kasm-1.14.0 이미지
+#baseImageId = '1692c5f95a70e' # 로컬 이미지
 
 BS = 16
 pad = (lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS).encode())
@@ -80,33 +80,45 @@ def generateServiceYaml(serviceName, servicePort, targetPort, nodePort):
 
     return serviceYaml
 
-# 컨테이너 관련 명령어 
-def createContainerCmd(port, pwd, imageId) : # vm+port 이름의 컨테이너 생성 
+# Pod yaml로 생성하기 
+def applyPodCmd(yamlFile):
+    return "kubectl apply -f" + yamlFile
+
+# deployment Pod 지우기  
+def deleteDeployPodCmd(deploymentName): 
+    return "kubectl delete deployment" + deploymentName 
+
+# service Pod 지우기  
+def deleteServicePodCmd(serviceName): 
+    return "kubectl delete service" + serviceName 
+
+# 컨테이너 관련 명령어
+def createContainerCmd(port, pwd, imageId) : # vm+port 이름의 컨테이너 생성
     return "docker create --shm-size=512m -p "+port+":6901 -e VNC_PW="+pwd+" --name vm"+port+" "+imageId
 
-def startContainerCmd(containerId) :    # containerid로 컨테이너 실행
+def startContainerCmd(containerId) :    # containerid로 컨테이너 실행 
     return "docker start "+containerId
 
 def stopContainerCmd(containerId) :     # containerid로 컨테이너 중지
     return "docker stop "+containerId
 
-def deleteContainerCmd(containerId) :   # containerid로 컨테이너 삭제 
+def deleteContainerCmd(containerId) :   # containerid로 컨테이너 삭제
     return "docker rm "+containerId
 
 def copyScriptToContainer(containerId) :
     return "docker cp /home/ubuntu/start.sh "+containerId+":/dockerstartup/"
 
 def changeVncScopeAndControl(containerId, scope, control, pwd) :
-    return "docker exec -it --user root "+ containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd 
+    return "docker exec -it --user root "+ containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
 
-# 이미지 관련 명령어 
+# 이미지 관련 명령어
 def createImgCmd(containerId, userId, port) : # registry.p2kcloud.com/base/userid:port 이름의 새로운 이미지 생성
     return "docker commit "+containerId+" registry.p2kcloud.com/base/"+userId+":"+port
-    
-def pushImgCmd(userId, port) :          # harbor에 이미지 저장 
+
+def pushImgCmd(userId, port) :          # harbor에 이미지 저장
     return "docker push registry.p2kcloud.com/base/"+userId+":"+port
 
-def deleteImgCmd(imageId) :             # imageid로 이미지 삭제 
+def deleteImgCmd(imageId) :             # imageid로 이미지 삭제
     return "docker rmi -f "+imageId
 
 def pullImgCmd() :      # harbor에서 kasm 이미지 pull -> 이미 pull 받아짐
@@ -115,20 +127,20 @@ def pullImgCmd() :      # harbor에서 kasm 이미지 pull -> 이미 pull 받아
 class AESCipher(object):
     def __init__(self, key):
         self.key = hashlib.sha256(key.encode()).digest()
-    
+
     def encrypt(self, message):
         message = message.encode()
         raw = pad(message)
         cipher = AES.new(self.key, AES.MODE_CBC, self.__iv().encode('utf8'))
         enc = cipher.encrypt(raw)
         return base64.b64encode(enc).decode('utf-8')
-    
+
     def decrypt(self, enc):
         enc = base64.b64decode(enc)
         cipher = AES.new(self.key, AES.MODE_CBC, self.__iv().encode('utf8'))
         dec = cipher.decrypt(enc)
         return unpad(dec).decode('utf-8')
-    
+
     def __iv(self):
         return chr(0) * 16
 
@@ -136,36 +148,56 @@ key = "thisiskey"
 aes = AESCipher(key)
 
 
-# spring 서버에서 컨테이너 생성 요청이 왔을 때, base 이미지로 컨테이너 생성하고 이미지 저장 
+# spring 서버에서 컨테이너 생성 요청이 왔을 때, base 이미지로 컨테이너 생성하고 이미지 저장
 @app.route('/create', methods=['POST'])
 def create():
-    
-    requestDTO = request.get_json() 
+
+    requestDTO = request.get_json()
     print("[create requestDTO] ", requestDTO)
     userId, port, pwd = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['password'])
     scope, control = str(requestDTO['scope']), str(requestDTO['control'])
-    
+
     stream1 = os.popen(createContainerCmd(port, pwd, baseImageId))
     containerId = stream1.read()[:12]
     time.sleep(5)
-    enContainerId = aes.encrypt(containerId) # containerId 암호화 
+    enContainerId = aes.encrypt(containerId) # containerId 암호화
 
     stream2 = os.popen(createImgCmd(containerId, userId, port))
     imageId = stream2.read()[7:20]
-    enImageId = aes.encrypt(imageId)  # imageId 암호화 
-    
+    enImageId = aes.encrypt(imageId)  # imageId 암호화
+    vmName = str(requestDTO['vmname'])
+    scriptPath = "/dockerstartup/start.sh"
+    nodePort = str(requestDTO['nodePort'])
+
     os.popen(startContainerCmd(containerId))
-    
+
     os.popen(copyScriptToContainer(containerId))
-    
-    os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
-    
+
+    #os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
+    #cmd1= "docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
+    #os.popen(cmd1)
+
+    # Depolyment yaml 파일 생성 
+    deploymentPodYaml = generateDeploymentPodYaml(vmName, vmName, imageId, port, scriptPath, scope, control, pwd)
+    deploymentFilePath = "/home/yaml/"+vmName+"Deployment.yaml"
+    with open(deploymentFilePath, 'w') as deploymentYamlFile:
+        deploymentYamlFile.write(deploymentPodYaml) 
+
+    # Service yaml 파일 생성 
+    servicePodYaml = generateServiceYaml(vmName, port, port, nodePort)
+    serviceFilePath = "/home/yaml/"+vmName+"Service.yaml"
+    with open(serviceFilePath, 'w') as serviceYamlFile:
+        serviceYamlFile.write(servicePodYaml)
+
+    print(deploymentPodYaml)
+    print(servicePodYaml)
+
     response = {
             'port': port,
             'containerId' : enContainerId,
             'imageId' : enImageId
         }
-    
+
     return jsonify(response), 200
 
 
@@ -173,37 +205,57 @@ def create():
 #spring 서버에서 가상환경 로드했을 때, 이미지로 컨테이너 생성 후 새로운 이미지로 저장
 @app.route('/load', methods=['POST'])
 def load() :
-    
+
     requestDTO = request.get_json()
     print("[load requestDTO] ", requestDTO)
     userId, port, pwd, imageId = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['password']), str(requestDTO['key'])
     deImageId = aes.decrypt(imageId)
-    
+
     stream1 = os.popen(createContainerCmd(port, pwd, deImageId))
     newContainerId = stream1.read()[:12]
     enContainerId = aes.encrypt(newContainerId)
-    
+
     stream2 = os.popen(createImgCmd(newContainerId, userId, port))
     newImageId = stream2.read()[7:20]
     enImageId = aes.encrypt(newImageId)
-    
+
+    scope, control = str(requestDTO['scope']), str(requestDTO['control'])
+    vmName = str(requestDTO['vmname'])
+    scriptPath = "/dockerstartup/start.sh"
+    nodePort = str(requestDTO['nodePort'])
+
     os.popen(startContainerCmd(newContainerId))
-    
+
     os.popen(copyScriptToContainer(newContainerId))
-    
+
+    # Depolyment yaml 파일 생성 
+    deploymentPodYaml = generateDeploymentPodYaml(vmName, vmName, imageId, port, scriptPath, scope, control, pwd)
+    deploymentFilePath = "/home/yaml/"+vmName+"Deployment.yaml"
+    with open(deploymentFilePath, 'w') as deploymentYamlFile:
+        deploymentYamlFile.write(deploymentPodYaml) 
+
+    # Service yaml 파일 생성 
+    servicePodYaml = generateServiceYaml(vmName, port, port, nodePort)
+    serviceFilePath = "/home/yaml/"+vmName+"Service.yaml"
+    with open(serviceFilePath, 'w') as serviceYamlFile:
+        serviceYamlFile.write(servicePodYaml)
+
     response = {
         'containerId' : enContainerId,
         'imageId' : enImageId
     }
-    
+
     return jsonify(response), 200
 
 
 
 # spring 서버에서 컨테이너 실행 요청이 왔을 때, 컨테이너 실행
 @app.route('/start', methods=['POST'])
-def start():    
-    
+def start():
+
+    print("hello")
+    print(request.get_json())
+
     requestDTO = request.get_json()
     print("[start requestDTO] ", requestDTO)
     port, containerId = str(requestDTO['port']), str(requestDTO['containerId'])
@@ -211,93 +263,112 @@ def start():
     pwd = str(requestDTO['password'])
     scope, control = str(requestDTO['scope']), str(requestDTO['control'])
 
-    os.popen(startContainerCmd(deContainerId))
-    
+    vmName = str(requestDTO['vmname'])
+
+    #os.popen(startContainerCmd(deContainerId)) Pod를 생성하면 자동으로 container가 실행되기 때문에 사용 안 함 
+
+    deploymentFilePath = "/home/yaml/"+vmName+"Deployment.yaml"
+    with open(deploymentFilePath, 'r') as deploymentYamlFile:
+        loadedDeployYaml = yaml.load(deploymentYamlFile, Loader=yaml.FullLoader)
+
+    serviceFilePath = "/home/yaml/"+vmName+"Service.yaml"
+    with open(serviceFilePath, 'w') as serviceYamlFile:
+        loadedServiceYaml = yaml.load(serviceYamlFile, Loader=yaml.FullLoader)
+
+    applyPodCmd(loadedDeployYaml)
+    applyPodCmd(loadedServiceYaml)
+
     time.sleep(1)
-    
-    os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
-    
+
+    #os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
+    #cmd1= "docker exec -it --user root "+containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd
+    #os.popen(cmd1)
+
     response = {
             'port' : port,
             'containerId' : containerId
         }
-    
+
     return jsonify(response), 200
 
 
 
 # spring 서버에서 컨테이너 중지 요청이 왔을 때, 컨테이너 중지
 @app.route('/stop', methods=['POST'])
-def stop():    
-    
+def stop():
+
     requestDTO = request.get_json()
     print("[stop requestDTO] ", requestDTO)
     port, containerId = str(requestDTO['port']), str(requestDTO['containerId'])
     deContainerId = aes.decrypt(containerId)
-    
-    os.popen(stopContainerCmd(deContainerId))
-    
+    vmName = str(requestDTO['vmname'])
+
+    # os.popen(stopContainerCmd(deContainerId))
+
+    deleteDeployPodCmd(vmName)
+    deleteServicePodCmd(vmName)
+
     response = {
             'port' : port,
             'containerId' : containerId
         }
-    
+
     return jsonify(response), 200
 
 
 
 # spring 서버에서 컨테이너 저장 요청이 왔을 때, 현재 컨테이너의 이미지 생성 -> 기존 이미지 삭제 -> push
 @app.route('/save', methods=['POST'])
-def save() :    
-    
+def save() : 
+
     requestDTO = request.get_json()
     print("[save requestDTO] ", requestDTO)
     userId, port, pwd = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['pwd'])
     containerId, imageId = str(requestDTO['containerId']), str(requestDTO['imageId'])
     deContainerId, deImageId = aes.decrypt(containerId), aes.decrypt(imageId)
-    
+
     stream1 = os.popen(createImgCmd(deContainerId, userId, port))
     newImageId = stream1.read()[7:20]
     enImageId = aes.encrypt(newImageId)
     print("1 : ", stream1.read())
-    
+
     stream2 = os.popen(deleteImgCmd(deImageId))
     print("2 : ", stream2.read())
-    
+
     stream3 = os.popen(pushImgCmd(userId, port))
     print("3 : ", stream3.read())
     time.sleep(3)
-    
+
     print("newImageId : ", newImageId)
     print("ennewImageId : ", enImageId)
-    
+
     response = {
             'containerId' : containerId,
             'imageId' : enImageId
         }
-    
+
     return jsonify(response), 200
 
 
 
-# spring 서버에서 컨테이너 삭제 요청이 왔을 때, 컨테이너, 이미지 삭제  
+# spring 서버에서 컨테이너 삭제 요청이 왔을 때, 컨테이너, 이미지 삭제
 @app.route('/delete', methods=['POST'])
-def delete():    
-    
+def delete():
+
     requestDTO = request.get_json()
     print("[delete requestDTO] ", requestDTO)
     userId, port = str(requestDTO['id']), str(requestDTO['port'])
     containerId, imageId = str(requestDTO['containerId']), str(requestDTO['imageId'])
     deContainerId, deImageId = aes.decrypt(containerId), aes.decrypt(imageId)
-    
+
     os.popen(deleteContainerCmd(deContainerId))
     os.popen(deleteImgCmd(deImageId))
-    
+
     response = {
             'port' : port,
             'containerId' : containerId
         }
-    
+
     return jsonify(response), 200
 
 

--- a/app_v2.py
+++ b/app_v2.py
@@ -277,7 +277,7 @@ def start():
         loadedDeployYaml = yaml.load(deploymentYamlFile, Loader=yaml.FullLoader)
 
     serviceFilePath = "/home/yaml/"+vmName+"Service.yaml"
-    with open(serviceFilePath, 'w') as serviceYamlFile:
+    with open(serviceFilePath, 'r') as serviceYamlFile:
         loadedServiceYaml = yaml.load(serviceYamlFile, Loader=yaml.FullLoader)
 
     applyPodCmd(loadedDeployYaml)

--- a/app_v2.py
+++ b/app_v2.py
@@ -1,0 +1,305 @@
+from flask import Flask, render_template, request, jsonify
+import os, time
+import base64
+import hashlib
+from Crypto.Cipher import AES
+import yaml
+
+app = Flask(__name__)
+
+baseImageId = '04a27ba84906' # kasm-1.14.0 이미지 
+#baseImageId = '1692c5f95a70e' # 로컬 이미지 
+
+BS = 16
+pad = (lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS).encode())
+unpad = (lambda s: s[:-ord(s[len(s)-1:])])
+
+# deployment pod 만드는 함수
+def generateDeploymentPodYaml(deploymentName, containerName, imageName, containerPort, scriptPath, scope, control, pwd) : 
+    deploymentDefinition = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": deploymentName}, 
+        "spec": {
+            "replicas": 1,
+            "selector": {
+                "matchLabels": {
+                    "app": "webdesktop" # service에서 pod를 선택할 때 구별하는 용도 
+                }
+            },
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app": "webdesktop" # 새로운 pod가 생성될 때 template 정의 
+                    }
+                },
+                "spec": { 
+                    "containers": [ 
+                        {
+                            "name": containerName, 
+                            "image": imageName, 
+                            "ports": [{"containerPort": containerPort}],
+                            "command": [scriptPath], # script 경로 (docker exec ~~)
+                            "args": [scope, control, pwd] # 함께 전달되는 인자 
+                        } 
+                    ], 
+                    "imagePullSecrets": [{"name": "harbor"}] # harbor라는 이름의 kubeconfig.yaml 파일 
+                }
+            }
+        }
+    }
+
+    # YAML로 변환하여 문자열로 반환합니다.
+    deploymentYaml = yaml.dump(deploymentDefinition, default_flow_style=False)
+
+    return deploymentYaml
+
+
+# service pod를 만드는 함수 (pod를 외부로 노출하기 위함)
+def generateServiceYaml(serviceName, servicePort, targetPort, nodePort):
+    # Service의 기본 구조를 딕셔너리로 정의합니다.
+    serviceDefinition = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": serviceName},
+        "spec": {
+            "type": "NodePort",
+            "selector": {"app": "webdesktop"},
+            "ports": [
+                {
+                    "port": servicePort, 
+                    "targetPort": targetPort, 
+                    "nodePort": nodePort # node_port는 30000~32768 
+                }
+            ]
+        }
+    }
+
+    # YAML로 변환하여 문자열로 반환합니다.
+    serviceYaml = yaml.dump(serviceDefinition, default_flow_style=False)
+
+    return serviceYaml
+
+# 컨테이너 관련 명령어 
+def createContainerCmd(port, pwd, imageId) : # vm+port 이름의 컨테이너 생성 
+    return "docker create --shm-size=512m -p "+port+":6901 -e VNC_PW="+pwd+" --name vm"+port+" "+imageId
+
+def startContainerCmd(containerId) :    # containerid로 컨테이너 실행
+    return "docker start "+containerId
+
+def stopContainerCmd(containerId) :     # containerid로 컨테이너 중지
+    return "docker stop "+containerId
+
+def deleteContainerCmd(containerId) :   # containerid로 컨테이너 삭제 
+    return "docker rm "+containerId
+
+def copyScriptToContainer(containerId) :
+    return "docker cp /home/ubuntu/start.sh "+containerId+":/dockerstartup/"
+
+def changeVncScopeAndControl(containerId, scope, control, pwd) :
+    return "docker exec -it --user root "+ containerId+" bash /dockerstartup/start.sh "+scope +" "+control+" "+pwd 
+
+# 이미지 관련 명령어 
+def createImgCmd(containerId, userId, port) : # registry.p2kcloud.com/base/userid:port 이름의 새로운 이미지 생성
+    return "docker commit "+containerId+" registry.p2kcloud.com/base/"+userId+":"+port
+    
+def pushImgCmd(userId, port) :          # harbor에 이미지 저장 
+    return "docker push registry.p2kcloud.com/base/"+userId+":"+port
+
+def deleteImgCmd(imageId) :             # imageid로 이미지 삭제 
+    return "docker rmi -f "+imageId
+
+def pullImgCmd() :      # harbor에서 kasm 이미지 pull -> 이미 pull 받아짐
+    return "docker pull registry.p2kcloud.com/base/vncdesktop"
+
+class AESCipher(object):
+    def __init__(self, key):
+        self.key = hashlib.sha256(key.encode()).digest()
+    
+    def encrypt(self, message):
+        message = message.encode()
+        raw = pad(message)
+        cipher = AES.new(self.key, AES.MODE_CBC, self.__iv().encode('utf8'))
+        enc = cipher.encrypt(raw)
+        return base64.b64encode(enc).decode('utf-8')
+    
+    def decrypt(self, enc):
+        enc = base64.b64decode(enc)
+        cipher = AES.new(self.key, AES.MODE_CBC, self.__iv().encode('utf8'))
+        dec = cipher.decrypt(enc)
+        return unpad(dec).decode('utf-8')
+    
+    def __iv(self):
+        return chr(0) * 16
+
+key = "thisiskey"
+aes = AESCipher(key)
+
+
+# spring 서버에서 컨테이너 생성 요청이 왔을 때, base 이미지로 컨테이너 생성하고 이미지 저장 
+@app.route('/create', methods=['POST'])
+def create():
+    
+    requestDTO = request.get_json() 
+    print("[create requestDTO] ", requestDTO)
+    userId, port, pwd = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['password'])
+    scope, control = str(requestDTO['scope']), str(requestDTO['control'])
+    
+    stream1 = os.popen(createContainerCmd(port, pwd, baseImageId))
+    containerId = stream1.read()[:12]
+    time.sleep(5)
+    enContainerId = aes.encrypt(containerId) # containerId 암호화 
+
+    stream2 = os.popen(createImgCmd(containerId, userId, port))
+    imageId = stream2.read()[7:20]
+    enImageId = aes.encrypt(imageId)  # imageId 암호화 
+    
+    os.popen(startContainerCmd(containerId))
+    
+    os.popen(copyScriptToContainer(containerId))
+    
+    os.popen(changeVncScopeAndControl(containerId, scope, control, pwd))
+    
+    response = {
+            'port': port,
+            'containerId' : enContainerId,
+            'imageId' : enImageId
+        }
+    
+    return jsonify(response), 200
+
+
+
+#spring 서버에서 가상환경 로드했을 때, 이미지로 컨테이너 생성 후 새로운 이미지로 저장
+@app.route('/load', methods=['POST'])
+def load() :
+    
+    requestDTO = request.get_json()
+    print("[load requestDTO] ", requestDTO)
+    userId, port, pwd, imageId = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['password']), str(requestDTO['key'])
+    deImageId = aes.decrypt(imageId)
+    
+    stream1 = os.popen(createContainerCmd(port, pwd, deImageId))
+    newContainerId = stream1.read()[:12]
+    enContainerId = aes.encrypt(newContainerId)
+    
+    stream2 = os.popen(createImgCmd(newContainerId, userId, port))
+    newImageId = stream2.read()[7:20]
+    enImageId = aes.encrypt(newImageId)
+    
+    os.popen(startContainerCmd(newContainerId))
+    
+    os.popen(copyScriptToContainer(newContainerId))
+    
+    response = {
+        'containerId' : enContainerId,
+        'imageId' : enImageId
+    }
+    
+    return jsonify(response), 200
+
+
+
+# spring 서버에서 컨테이너 실행 요청이 왔을 때, 컨테이너 실행
+@app.route('/start', methods=['POST'])
+def start():    
+    
+    requestDTO = request.get_json()
+    print("[start requestDTO] ", requestDTO)
+    port, containerId = str(requestDTO['port']), str(requestDTO['containerId'])
+    deContainerId = aes.decrypt(containerId)
+    pwd = str(requestDTO['password'])
+    scope, control = str(requestDTO['scope']), str(requestDTO['control'])
+
+    os.popen(startContainerCmd(deContainerId))
+    
+    time.sleep(1)
+    
+    os.popen(changeVncScopeAndControl(deContainerId, scope, control, pwd))
+    
+    response = {
+            'port' : port,
+            'containerId' : containerId
+        }
+    
+    return jsonify(response), 200
+
+
+
+# spring 서버에서 컨테이너 중지 요청이 왔을 때, 컨테이너 중지
+@app.route('/stop', methods=['POST'])
+def stop():    
+    
+    requestDTO = request.get_json()
+    print("[stop requestDTO] ", requestDTO)
+    port, containerId = str(requestDTO['port']), str(requestDTO['containerId'])
+    deContainerId = aes.decrypt(containerId)
+    
+    os.popen(stopContainerCmd(deContainerId))
+    
+    response = {
+            'port' : port,
+            'containerId' : containerId
+        }
+    
+    return jsonify(response), 200
+
+
+
+# spring 서버에서 컨테이너 저장 요청이 왔을 때, 현재 컨테이너의 이미지 생성 -> 기존 이미지 삭제 -> push
+@app.route('/save', methods=['POST'])
+def save() :    
+    
+    requestDTO = request.get_json()
+    print("[save requestDTO] ", requestDTO)
+    userId, port, pwd = str(requestDTO['id']), str(requestDTO['port']), str(requestDTO['pwd'])
+    containerId, imageId = str(requestDTO['containerId']), str(requestDTO['imageId'])
+    deContainerId, deImageId = aes.decrypt(containerId), aes.decrypt(imageId)
+    
+    stream1 = os.popen(createImgCmd(deContainerId, userId, port))
+    newImageId = stream1.read()[7:20]
+    enImageId = aes.encrypt(newImageId)
+    print("1 : ", stream1.read())
+    
+    stream2 = os.popen(deleteImgCmd(deImageId))
+    print("2 : ", stream2.read())
+    
+    stream3 = os.popen(pushImgCmd(userId, port))
+    print("3 : ", stream3.read())
+    time.sleep(3)
+    
+    print("newImageId : ", newImageId)
+    print("ennewImageId : ", enImageId)
+    
+    response = {
+            'containerId' : containerId,
+            'imageId' : enImageId
+        }
+    
+    return jsonify(response), 200
+
+
+
+# spring 서버에서 컨테이너 삭제 요청이 왔을 때, 컨테이너, 이미지 삭제  
+@app.route('/delete', methods=['POST'])
+def delete():    
+    
+    requestDTO = request.get_json()
+    print("[delete requestDTO] ", requestDTO)
+    userId, port = str(requestDTO['id']), str(requestDTO['port'])
+    containerId, imageId = str(requestDTO['containerId']), str(requestDTO['imageId'])
+    deContainerId, deImageId = aes.decrypt(containerId), aes.decrypt(imageId)
+    
+    os.popen(deleteContainerCmd(deContainerId))
+    os.popen(deleteImgCmd(deImageId))
+    
+    response = {
+            'port' : port,
+            'containerId' : containerId
+        }
+    
+    return jsonify(response), 200
+
+
+if __name__ == '__main__':
+    app.run('0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
작성한 코드 
- 기존에 작성된 코드
  - app.py 
- 새롭게 작성된 코드 
  - app_v2.py
  - 기존에 작성된 코드에서 docker로 image 관리하는 코드는 유지 
  
- Pod 생성하는 yaml 파일 작성 함수 
  - deployment, service pod 작성 
  - container 기본 접속 코드는 6901로 고정 
  - pod servicePort는 create할 때 만들어지는 port 부여
 
- 접속하는 로직 
  - 접속은 [노드 ip]:[노드 포트] (노드 포트를 이용해서 pod를 노출시켰기 때문)
  - kubectl 명령 실행 시 접속 권한이 필요하기 때문에 --kubeconfig 옵션 부여